### PR TITLE
Do not need repeated "uncut area" warnings

### DIFF
--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -2285,6 +2285,12 @@ def getPath3axis(context,operation):
 		chunksFromCurve=[]
 		lastchunks=[]
 		centers=None
+		checkCenters=False
+		
+		if o.dist_between_paths>o.cutter_diameter/2.0:
+			checkCenters=True
+			o.warnings=o.warnings+'Distance between paths larger\n	than cutter radius can result in uncut areas!\n '
+
 		while len(p)>0:
 			nchunks=polyToChunks(p,o.min.z)
 			nchunks=limitChunks(nchunks,o)
@@ -2294,9 +2300,7 @@ def getPath3axis(context,operation):
 			
 			pnew=outlinePoly(p,o.dist_between_paths,o.circle_detail,o.optimize,o.optimize_threshold,False)
 			
-			if o.dist_between_paths>o.cutter_diameter/2.0:#this mess under this IF condition is here ONLY because of the ability to have stepover> than cutter radius. Other CAM softwares don't allow this at all, maybe because of this mathematical problem and performance cost, but into soft materials, this is good to have.
-				o.warnings=o.warnings+'Distance between paths larger\n	than cutter radius can result in uncut areas!\n '
-
+			if checkCenters:
 				contours_before=len(p)
 				
 				if centers==None:


### PR DESCRIPTION
Fixed pocket operation so that it would not give as many "uncut area possibility" warnings as there are step-over paths.

Note: For some reason GitHub is saying I changed a lot more than I really did... See commit notes for details.