### PR TITLE
G4 Dwell code should be on the separate line for LinuxCNC v2.7

### DIFF
--- a/scripts/addons/cam/nc/emc2b.py
+++ b/scripts/addons/cam/nc/emc2b.py
@@ -22,7 +22,9 @@ class Creator(iso_modal.Creator):
 
     def PROGRAM(self): return None
     def PROGRAM_END(self): return( 'T0' + self.SPACE() + 'M06' + self.SPACE() + 'M02')
-        
+    def dwell(self, t):
+    	self.write('\n')
+    	iso_modal.Creator.dwell(self, t)
 ############################################################################
 ## Begin Program 
 


### PR DESCRIPTION
G4 command can't be on the same line with M3 comand. Thus LinuxCNC v2.7 Axis GUI prints error and doesn't open file at all. 