### PR TITLE
Add "Enable manual tool change" checkbox to CAM Machine section

### DIFF
--- a/scripts/addons/cam/__init__.py
+++ b/scripts/addons/cam/__init__.py
@@ -134,6 +134,12 @@ class machineSettings(bpy.types.PropertyGroup):
 	'''
 	collet_size=bpy.props.FloatProperty(name="#Collet size", description="Collet size for collision detection",default=33, min=0.00001, max=320000,precision=PRECISION , unit="LENGTH")
 	#exporter_start = bpy.props.StringProperty(name="exporter start", default="%")
+	enable_manual_tool_change = bpy.props.BoolProperty(
+		name="Enable manual tool change",
+		description="Enable manual tool changing logic which involves G43 command",
+		default=True
+    )
+
 
 class PackObjectsSettings(bpy.types.PropertyGroup):
 	'''stores all data for machines'''

--- a/scripts/addons/cam/nc/emc2b.py
+++ b/scripts/addons/cam/nc/emc2b.py
@@ -1,3 +1,4 @@
+import bpy
 from . import nc
 from . import iso_modal
 import math
@@ -21,10 +22,16 @@ class Creator(iso_modal.Creator):
             return ' '
 
     def PROGRAM(self): return None
-    def PROGRAM_END(self): return( 'T0' + self.SPACE() + 'M06' + self.SPACE() + 'M02')
+
+    def PROGRAM_END(self):
+        if bpy.context.scene.cam_machine.enable_manual_tool_change:
+            return( 'T0' + self.SPACE() + 'M06' + self.SPACE() + 'M02')
+        else:
+            return('M02')
+
     def dwell(self, t):
-    	self.write('\n')
-    	iso_modal.Creator.dwell(self, t)
+        self.write('\n')
+        iso_modal.Creator.dwell(self, t)
 ############################################################################
 ## Begin Program 
 

--- a/scripts/addons/cam/ui.py
+++ b/scripts/addons/cam/ui.py
@@ -130,6 +130,7 @@ class CAM_MACHINE_Panel(CAMButtonsPanel, bpy.types.Panel):
 			#layout.prop(ao,'axis5')
 			#layout.prop(ao,'collet_size')
 			#
+			layout.prop(ao,'enable_manual_tool_change')
 
 class CAM_MATERIAL_Panel(CAMButtonsPanel, bpy.types.Panel):	 
 	"""CAM material panel"""

--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -1161,7 +1161,8 @@ def exportGcodePath(filename,vertslist,operations):
 		
 		#write tool, not working yet probably 
 		#print (last_cutter)
-		if last_cutter!=[o.cutter_id,o.cutter_diameter,o.cutter_type,o.cutter_flutes]:
+		if last_cutter!=[o.cutter_id,o.cutter_diameter,o.cutter_type,o.cutter_flutes] and \
+			m.enable_manual_tool_change:
 			c.comment('Tool change - D = %s type %s flutes %s' % ( strInUnits(o.cutter_diameter,4),o.cutter_type, o.cutter_flutes))
 			c.tool_change(o.cutter_id)
 			c.flush_nc()


### PR DESCRIPTION
Pull request for #43 related issue.

Using the manual tool changer only makes sense if you have tool holders
that remain with the tool (Cat, NMTB, Kwik Switch etc.)
when changed thus preserving the location of the tool to the spindle.

If you don't have such tool holders you don't need that feature.