### PR TITLE
Change the policy of automatic toolpath selection

### DIFF
--- a/scripts/addons/cam/ops.py
+++ b/scripts/addons/cam/ops.py
@@ -23,6 +23,7 @@
 
 import bpy
 import subprocess,os, sys, threading
+import cam
 from cam import utils, pack,polygon_utils_cam,chunk,simple
 from bpy.props import *
 import shapely
@@ -607,7 +608,11 @@ class CamOperationRemove(bpy.types.Operator):
 			bpy.ops.object.delete(True)
 		except:
 			pass
-		
+
+		ao = scene.cam_operations[scene.cam_active_operation]
+		if ao.path_object_name in cam.was_hidden_dict:
+			del cam.was_hidden_dict[ao.path_object_name]
+
 		scene.cam_operations.remove(scene.cam_active_operation)
 		if scene.cam_active_operation>0:
 			scene.cam_active_operation-=1

--- a/scripts/addons/cam/ui.py
+++ b/scripts/addons/cam/ui.py
@@ -354,7 +354,7 @@ class CAM_OPERATIONS_Panel(CAMButtonsPanel, bpy.types.Panel):
 
 				if use_experimental and ao.geometry_source in ['OBJECT', 'GROUP']:
 					layout.prop(ao, 'use_modifiers')
-
+				layout.prop(ao, 'hide_all_others')
 
 									 
 class CAM_INFO_Panel(CAMButtonsPanel, bpy.types.Panel):


### PR DESCRIPTION
1. If toolpath was hidden, it becomes visible on operation selection.
   After selection of other operation it returns back to its hidden state.

2. On operation selection all other cam toolpathes objects become deselected

3. Added checkbox option under "CAM operations" > "Hide all others"
   This options gives ability to user to automatically hide all other
   cam toolpath objects except the current operation cam toolpath.