### PR TITLE
Add support for running OCL in Windows

### DIFF
--- a/scripts/addons/cam/opencamlib/oclSample.py
+++ b/scripts/addons/cam/opencamlib/oclSample.py
@@ -1,13 +1,16 @@
+import os
 import ocl
 import tempfile
 import pyocl
 import camvtk
 
-stl = camvtk.STLSurf(tempfile.gettempdir()+"/model0.stl")
+print(os.path.join(tempfile.gettempdir(), "model0.stl"))
+
+stl = camvtk.STLSurf(os.path.join(tempfile.gettempdir(), "model0.stl"))
 stl_polydata = stl.src.GetOutput()
 stl_surf = ocl.STLSurf()
 camvtk.vtkPolyData2OCLSTL(stl_polydata, stl_surf)
-csv_file = open(tempfile.gettempdir()+'/ocl_settings.txt','r')
+csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_settings.txt'),'r')
 op_cutter_type = csv_file.readline().split()[0]
 op_cutter_diameter = float( csv_file.readline() )
 op_minz = float( csv_file.readline() )
@@ -28,7 +31,7 @@ bdc = ocl.BatchDropCutter()
 bdc.setSTL(stl_surf)
 bdc.setCutter(cutter)
 
-csv_file = open(tempfile.gettempdir()+'/ocl_chunks.txt','r')
+csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_chunks.txt'),'r')
 for text_line in csv_file:
 	sample_point = [ float(coord) for coord in text_line.split() ]
 	bdc.appendPoint( ocl.CLPoint( sample_point[0]*1000, sample_point[1]*1000, op_minz * 1000 ) )
@@ -38,7 +41,7 @@ bdc.run()
 
 cl_points = bdc.getCLPoints()
 
-csv_file = open(tempfile.gettempdir()+'/ocl_chunk_samples.txt', 'w')
+csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_chunk_samples.txt'), 'w')
 for point in cl_points:
 	csv_file.write( str(point.z) + '\n' )
 csv_file.close()

--- a/scripts/addons/cam/opencamlib/oclSample.py
+++ b/scripts/addons/cam/opencamlib/oclSample.py
@@ -4,8 +4,6 @@ import tempfile
 import pyocl
 import camvtk
 
-print(os.path.join(tempfile.gettempdir(), "model0.stl"))
-
 stl = camvtk.STLSurf(os.path.join(tempfile.gettempdir(), "model0.stl"))
 stl_polydata = stl.src.GetOutput()
 stl_surf = ocl.STLSurf()
@@ -24,7 +22,7 @@ elif op_cutter_type == 'BALLNOSE':
 elif op_cutter_type == 'VCARVE':
 	cutter = ocl.ConeCutter( op_cutter_diameter*1000, 1, cutter_length)
 else:
-	print "Cutter unsupported: " + op_cutter_type + '\n'
+	print("Cutter unsupported: {0}\n".format(op_cutter_type))
 	quit()
 #add BullCutter
 bdc = ocl.BatchDropCutter()

--- a/scripts/addons/cam/opencamlib/opencamlib.py
+++ b/scripts/addons/cam/opencamlib/opencamlib.py
@@ -12,28 +12,35 @@ from shapely import geometry as sgeometry
 
 OCL_SCALE = 1000
 
+PYTHON_BIN = ""
+
+if os.name == "nt":
+	PYTHON_BIN = "python"
+elif os.name == "posix":
+	PYTHON_BIN = "python2.7"
+
 def operationSettingsToCSV(operation):
-	csv_file = open(tempfile.gettempdir()+'/ocl_settings.txt','w')
+	csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_settings.txt'),'w')
 	csv_file.write( str(operation.cutter_type) + '\n')
 	csv_file.write( str(operation.cutter_diameter) + '\n' )
 	csv_file.write( str(operation.minz) + '\n' )
 	csv_file.close()
 
 def pointsToCSV(operation, points):
-	csv_file = open(tempfile.gettempdir()+'/ocl_chunks.txt','w')
+	csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_chunks.txt'),'w')
 	for point in points:
 		csv_file.write( str(point[0]) + ' ' + str(point[1]) + '\n')
 	csv_file.close()
 
 def pointSamplesFromCSV(points):
-	csv_file = open(tempfile.gettempdir()+'/ocl_chunk_samples.txt','r')
+	csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_chunk_samples.txt'),'r')
 	for point in points:
 		point[2] = float(csv_file.readline()) / OCL_SCALE;
 		#print(str(point[2]))
 	csv_file.close()
 
 def chunkPointsToCSV(operation, chunks):
-	csv_file = open(tempfile.gettempdir()+'/ocl_chunks.txt','w')
+	csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_chunks.txt'),'w')
 	for ch in chunks:
 		p_index = 0;
 		for point in ch.points:
@@ -45,7 +52,7 @@ def chunkPointsToCSV(operation, chunks):
 	csv_file.close()
 
 def chunkPointSamplesFromCSV(chunks):
-	csv_file = open(tempfile.gettempdir()+'/ocl_chunk_samples.txt','r')
+	csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_chunk_samples.txt'),'r')
 	for ch in chunks:
 		p_index = 0;
 		for point in ch.points:
@@ -59,14 +66,14 @@ def chunkPointSamplesFromCSV(chunks):
 	csv_file.close()
 
 def resampleChunkPointsToCSV(operation, chunks_to_resample):
-	csv_file = open(tempfile.gettempdir()+'/ocl_chunks.txt','w')
+	csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_chunks.txt'),'w')
 	for chunk, i_start, i_length in chunks_to_resample:
 		for p_index in range(i_start, i_start+i_length):
 				csv_file.write( str(chunk.points[p_index][0]) + ' ' + str(chunk.points[p_index][1]) + '\n')
 	csv_file.close()
 
 def chunkPointsResampleFromCSV(chunks_to_resample):
-	csv_file = open(tempfile.gettempdir()+'/ocl_chunk_samples.txt','r')
+	csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_chunk_samples.txt'),'r')
 	for chunk, i_start, i_length in chunks_to_resample:
 		for p_index in range(i_start, i_start+i_length):
 			z = float(csv_file.readline()) / OCL_SCALE;
@@ -81,7 +88,8 @@ def exportModelsToSTL(operation):
 		bpy.ops.object.duplicate( linked=False )
 		collision_object = bpy.context.scene.objects.active
 		#bpy.context.scene.objects.selected = collision_object
-		file_name = tempfile.gettempdir()+"/model"+str(file_number)+".stl"
+		file_name = os.path.join(tempfile.gettempdir(),"model{0}.stl".format(str(file_number)))
+		print(file_name)
 		bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
 		bpy.ops.transform.resize(value=(OCL_SCALE, OCL_SCALE, OCL_SCALE), constraint_axis=(False, False, False), constraint_orientation='GLOBAL', mirror=False, proportional='DISABLED', proportional_edit_falloff='SMOOTH', proportional_size=1, snap=False, snap_target='CLOSEST', snap_point=(0, 0, 0), snap_align=False, snap_normal=(0, 0, 0), texture_space=False, release_confirm=False)
 		bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
@@ -90,34 +98,34 @@ def exportModelsToSTL(operation):
 		file_number += 1
 	
 def oclSamplePoints(operation, points):
-	print(tempfile.gettempdir()+"/oclSamplePoints\n")
+	print(os.path.join(tempfile.gettempdir(), "oclSamplePoints\n"))
 	operationSettingsToCSV(operation)
 	pointsToCSV(operation, points)
 	exportModelsToSTL(operation)
-	if os.path.isdir(bpy.utils.script_path_pref()+"/addons/cam/opencamlib"):
-		call([ "python2.7", bpy.utils.script_path_pref()+"/addons/cam/opencamlib/oclSample.py"])
+	if os.path.isdir(os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib")):
+		call([ PYTHON_BIN, os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib", "oclSample.py")])
 	else:
-		call([ "python2.7", bpy.utils.script_path_pref()+"/addons/cam/opencamlib/oclSample.py"])
+		call([ PYTHON_BIN, os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib", "oclSample.py")])
 	pointSamplesFromCSV(points)
 
 def oclSample(operation, chunks):
 	operationSettingsToCSV(operation)
 	chunkPointsToCSV(operation, chunks)
 	exportModelsToSTL(operation)
-	if os.path.isdir(bpy.utils.script_path_pref()+"/addons/cam/opencamlib"):
-		call([ "python2.7", bpy.utils.script_path_pref()+"/addons/cam/opencamlib/oclSample.py"])
+	if os.path.isdir(os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib")):
+		call([ PYTHON_BIN, os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib", "oclSample.py")])
 	else:
-		call([ "python2.7", bpy.utils.script_path_pref()+"/addons/cam/opencamlib/oclSample.py"])
+		call([ PYTHON_BIN, os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib", "oclSample.py")])
 	chunkPointSamplesFromCSV(chunks)
 
 def oclResampleChunks(operation, chunks_to_resample):
 	operationSettingsToCSV(operation)
 	resampleChunkPointsToCSV(operation, chunks_to_resample)
 	#exportModelsToSTL(operation)
-	if os.path.isdir(bpy.utils.script_path_pref()+"/addons/cam/opencamlib"):
-		call([ "python2.7", bpy.utils.script_path_pref()+"/addons/cam/opencamlib/oclSample.py"])
+	if os.path.isdir(os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib")):
+		call([ PYTHON_BIN, os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib", "oclSample.py")])
 	else:
-		call([ "python2.7", bpy.utils.script_path_pref()+"/addons/cam/opencamlib/oclSample.py"])
+		call([ PYTHON_BIN, os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib", "oclSample.py")])
 	chunkPointsResampleFromCSV(chunks_to_resample)
 def oclWaterlineLayerHeights( operation ):
 	layers = []
@@ -133,7 +141,7 @@ def oclWaterlineLayerHeights( operation ):
 
 def oclWaterlineHeightsToCSV( operation ):
 	layers = oclWaterlineLayerHeights( operation )
-	csv_file = open(tempfile.gettempdir()+'/ocl_wl_heights.txt', 'w')
+	csv_file = open(os.path.join(tempfile.gettempdir(), 'ocl_wl_heights.txt'), 'w')
 	for layer in layers:
 		csv_file.write( str(layer*1000)+'\n')
 	csv_file.close()
@@ -142,7 +150,7 @@ def waterlineChunksFromCSV( operation, chunks ):
 	layers = oclWaterlineLayerHeights( operation )
 	wl_index = 0
 	for layer in layers:
-		csv_file = open(tempfile.gettempdir() + '/oclWaterline' + str(wl_index) + '.txt', 'r')
+		csv_file = open(os.path.join(tempfile.gettempdir(), 'oclWaterline') + str(wl_index) + '.txt', 'r')
 		print(str(wl_index) + "\n")
 		for line in csv_file:
 			if( line[0] == 'l'):
@@ -158,17 +166,17 @@ def oclGetMedialAxis(operation, chunks):
 	oclWaterlineHeightsToCSV( operation )
 	operationSettingsToCSV( operation )
 	curvesToCSV( operation )
-	call([ "python2.7", bpy.utils.script_path_pref()+"/addons/cam/opencamlib/ocl.py"])
+	call([ PYTHON_BIN, os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib", "ocl.py")])
 	waterlineChunksFromCSV( operation, chunks )
 
 def oclGetWaterline(operation, chunks):
 	oclWaterlineHeightsToCSV( operation )
 	operationSettingsToCSV( operation )
 	exportModelsToSTL( operation )
-	if os.path.isdir(bpy.utils.script_path_pref()+"/addons/cam/opencamlib"):
-		call([ "python2.7", bpy.utils.script_path_pref()+"/addons/cam/opencamlib/oclWaterline.py"])
+	if os.path.isdir(os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib")):
+		call([ os.path.join(PYTHON_BIN, bpy.utils.script_path_pref(), "addons", "cam", "opencamlib", "oclWaterline.py")])
 	else:
-		call([ "python2.7", bpy.utils.script_path_pref()+"/addons/cam/opencamlib/oclWaterline.py"])
+		call([ PYTHON_BIN, os.path.join(bpy.utils.script_path_pref(), "addons", "cam", "opencamlib", "oclWaterline.py")])
 	waterlineChunksFromCSV( operation, chunks )
 
 #def oclFillMedialAxis(operation):

--- a/scripts/addons/cam/opencamlib/opencamlib.py
+++ b/scripts/addons/cam/opencamlib/opencamlib.py
@@ -89,7 +89,6 @@ def exportModelsToSTL(operation):
 		collision_object = bpy.context.scene.objects.active
 		#bpy.context.scene.objects.selected = collision_object
 		file_name = os.path.join(tempfile.gettempdir(),"model{0}.stl".format(str(file_number)))
-		print(file_name)
 		bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
 		bpy.ops.transform.resize(value=(OCL_SCALE, OCL_SCALE, OCL_SCALE), constraint_axis=(False, False, False), constraint_orientation='GLOBAL', mirror=False, proportional='DISABLED', proportional_edit_falloff='SMOOTH', proportional_size=1, snap=False, snap_target='CLOSEST', snap_point=(0, 0, 0), snap_align=False, snap_normal=(0, 0, 0), texture_space=False, release_confirm=False)
 		bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)


### PR DESCRIPTION
this changes some string concatenation with string format and sets the python binary acording the system

[ocl.zip](https://github.com/vilemnovak/blendercam/files/748732/ocl.zip)
http://www.lfd.uci.edu/~gohlke/pythonlibs/#vtk
[pyocl.zip](https://github.com/vilemnovak/blendercam/files/749180/pyocl.zip)

for python27_x64

![blender_ocl](https://cloud.githubusercontent.com/assets/184088/22564169/cfb4d8ca-e983-11e6-8750-5652052b19d3.png)

