### PR TITLE
Add missing unary_union function import in operation_utils.py

### DIFF
--- a/fabex/utilities/operation_utils.py
+++ b/fabex/utilities/operation_utils.py
@@ -19,6 +19,7 @@ import numpy as np
 import pickle
 
 from shapely.geometry import Polygon
+from shapely.ops import unary_union
 
 import bpy
 from bpy_extras import object_utils


### PR DESCRIPTION
The function `get_ambient()` in `fabex/utilities/operation_utils.py` calls `shapely.ops.unary_union()` but was not imported.

This was breaking the Limit Curve feature in (at least) Parallel Strategies.